### PR TITLE
recipe/cmake.patch: fix install prefix computation

### DIFF
--- a/recipe/cmake.patch
+++ b/recipe/cmake.patch
@@ -9,7 +9,7 @@ index 342c37d..2061041 100644
 -include(${CMAKE_CURRENT_LIST_DIR}/LeptonicaTargets.cmake)
 +#include(${CMAKE_CURRENT_LIST_DIR}/LeptonicaTargets.cmake)
 +
-+get_filename_component(_leptonica_install_prefix "${CMAKE_CURRENT_LIST_DIR}/../" ABSOLUTE)
++get_filename_component(_leptonica_install_prefix "${CMAKE_CURRENT_LIST_DIR}/../../../" ABSOLUTE)
  
  # ======================================================
  #  Version variables:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - cmake.patch  # [win]
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win and vc<14]
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}


### PR DESCRIPTION
Based on my attempts to build Tesseract on Windows and looking at the files, the patch needs tweaking to properly declare the Leptonica installation prefix. We want $PREFIX, and the CMake file is installed in `$PREFIX/lib/cmake/leptonica/`.

* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
