### PR TITLE
Don't use `sw` when building on Windows

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,34 +1,16 @@
 mkdir build
 cd build
 
-curl -fsSOL https://software-network.org/client/sw-master-windows_x86_64-client.zip
-if errorlevel 1 exit 1
-
-unzip sw-master-windows_x86_64-client.zip -d .
-if errorlevel 1 exit 1
-
-set PATH=%PATH%;%CD%
-
-sw setup
-if errorlevel 1 exit 1
-
-:: As of July 2023, the build system for this package can run into issues if the
-:: version of `cl` found via %PATH% is not exactly the same as the version used
-:: by MSBuild. The only way I can figure out to avoid the problem is to avoid
-:: MSBuild altogether, which can be done by using the NMake Makefiles generator,
-:: as well as explicitly specifying the full path to the desired compilers.
-set "clpathunix=%VCToolsInstallDir%bin\Hostx64\x64\cl.exe"
-set "clpathunix=%clpathunix:\=/%"
-
 cmake %CMAKE_ARGS% ^
       -D BUILD_PROG=1 ^
+      -D CMAKE_BUILD_TYPE=Release ^
       -D CMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
       -D CMAKE_INCLUDE_PATH=%LIBRARY_INC% ^
       -D CMAKE_LIBRARY_PATH=%LIBRARY_LIB% ^
+      -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+      -D SW_BUILD=OFF ^
       -D BUILD_SHARED_LIBS=ON ^
       -D CMAKE_MODULE_LINKER_FLAGS=-whole-archive ^
-      -D "CMAKE_C_COMPILER=%clpathunix%" ^
-      -D "CMAKE_CXX_COMPILER=%clpathunix%" ^
       -G "NMake Makefiles" ^
       ..
 if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - cmake.patch  # [win]
 
 build:
-  number: 2
+  number: 3
   skip: true  # [win and vc<14]
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}
@@ -31,9 +31,6 @@ requirements:
     - m4  # [not win]
     - pkg-config  # [not win]
     - cmake  # [win]
-    # latest build of 7.71.1 (build 6) is broken
-    - curl <7.71.1  # [win]
-    - m2-unzip  # [win]
   host:
     - giflib  # [not win]
     - libjpeg-turbo


### PR DESCRIPTION
After all that effort to get it to work ... it turns out that the build just works on Windows if we don't use `sw`, and just pick up the conda-forge dependencies. And in my testing, we need a non-`sw` build in order to successfully build Tesseract against the newest Leptonica.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
